### PR TITLE
Song queue

### DIFF
--- a/app/controllers/admin/curators_controller.rb
+++ b/app/controllers/admin/curators_controller.rb
@@ -30,6 +30,8 @@ class Admin::CuratorsController < Admin::AdminController
   end
 
   def show
+    # Our job queues sends at midday UTC
+    @next_send = Time.now.utc.hour < 12 ? Date.today : Date.tomorrow
   end
 
   def edit

--- a/app/controllers/admin/songs_controller.rb
+++ b/app/controllers/admin/songs_controller.rb
@@ -5,6 +5,17 @@ class Admin::SongsController < Admin::AdminController
   def index
     @search = params[:q]
     @songs = @curator.songs
+
+    @type = params[:type]
+    case @type
+    when 'queued'
+      @songs = @songs.queued
+    when 'sent'
+      @songs = @songs.sent
+    else
+      @type = nil
+    end
+
     @songs = @songs.search(@search) unless @search.blank?
     @songs = @songs.order(created_at: :desc).page(params[:page]).per(5)
   end

--- a/app/views/admin/curators/show.html.erb
+++ b/app/views/admin/curators/show.html.erb
@@ -50,7 +50,13 @@
         Please <%= link_to "add a song now", new_admin_curator_song_path(@curator) %>.
       </div>
     <% end %>
-    <%= render partial: "admin/songs/songs", object: @curator.songs.order(:created_at).last(3) %>
+
+    <% @curator.songs.queued.order(:created_at).first(5).each_with_index do |song, index| %>
+      <%= render song do %>
+        <%= render partial: "admin/songs/song_footer",
+                   locals: { song: song, date: @next_send + index.days } %>
+      <% end %>
+    <% end %>
 
     <% unless @curator.songs.empty? %>
       <div class="m-t-3 clearfix">

--- a/app/views/admin/songs/_song_footer.html.erb
+++ b/app/views/admin/songs/_song_footer.html.erb
@@ -1,0 +1,30 @@
+<div class="card-footer">
+  <div class="row m-x-0 flex-items-xs-between flex-items-xs-middle">
+    <div class="text-nowrap">
+      <% if song.sent_at.nil? %>
+        <span class="text-warning">
+          <% if defined? date %>
+            Queued for <%= date.to_s(:long) %>
+          <% else %>
+            Queued to send
+          <% end %>
+        </span>
+      <% else %>
+        <span class="text-success">
+          Sent <%= song.sent_at.to_date.to_s(:long) %>
+        </span>
+      <% end %>
+    </div>
+    <div class="row m-x-0">
+      <% if current_user.admin? and song.curator != Curator.random %>
+        <%= button_to "Random!", admin_random_copy_path(song_id: song.id),
+          method: "post", class: "btn btn-secondary m-r-1",
+          data: {
+            confirm: "Really copy to random song queue?",
+            disable: true
+          } %>
+      <% end %>
+      <%= link_to "Edit song", edit_admin_curator_song_path(@curator, song), class: "btn btn-secondary" %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/songs/_songs.html.erb
+++ b/app/views/admin/songs/_songs.html.erb
@@ -1,30 +1,5 @@
 <% songs.each do |song| %>
   <%= render song do %>
-    <div class="card-footer">
-      <div class="row m-x-0 flex-items-xs-between flex-items-xs-middle">
-        <div class="text-nowrap">
-          <% if song.sent_at.nil? %>
-            <span class="text-warning">
-              Queued to send
-            </span>
-          <% else %>
-            <span class="text-success">
-              Sent <%= song.sent_at.to_date.to_s(:long) %>
-            </span>
-          <% end %>
-        </div>
-        <div class="row m-x-0">
-          <% if current_user.admin? and song.curator != Curator.random %>
-            <%= button_to "Random!", admin_random_copy_path(song_id: song.id),
-              method: "post", class: "btn btn-secondary m-r-1",
-              data: {
-                confirm: "Really copy to random song queue?",
-                disable: true
-              } %>
-          <% end %>
-          <%= link_to "Edit song", edit_admin_curator_song_path(@curator, song), class: "btn btn-secondary" %>
-        </div>
-      </div>
-    </div>
+    <%= render partial: "admin/songs/song_footer", object: song, as: :song %>
   <% end %>
 <% end %>

--- a/app/views/admin/songs/index.html.erb
+++ b/app/views/admin/songs/index.html.erb
@@ -7,6 +7,11 @@
 <div class="clearfix m-b-2">
   <h1 class="pull-sm-left"><%= yield :title %></h1>
   <div class="pull-sm-right">
+    <div class="btn-group m-r-2">
+      <%= link_to "All", url_for(type: nil), class: "btn btn-secondary #{"active" if @type.nil?}" %>
+      <%= link_to "Queued", url_for(type: "queued"), class: "btn btn-secondary #{"active" if @type == "queued"}" %>
+      <%= link_to "Sent", url_for(type: "sent"), class: "btn btn-secondary #{"active" if @type == "sent"}" %>
+    </div>
     <%= link_to "Add song", new_admin_curator_song_path(@curator), class: "btn btn-primary" %>
   </div>
 </div>


### PR DESCRIPTION
@shannonbyrne I've got a couple of tweaks to the song queue here, to hopefully make it clearer for curators. Can you check this out and merge the pull request if you approve, or give feedback if not?

### Queue dates

On the main curator page, we now show up to 5 queued songs, with an estimated send date for each:

![queue-dates](https://cloud.githubusercontent.com/assets/68917/17830497/5e220502-66c5-11e6-959a-174d3b1c97dd.png)

### Song queue filtering

When you click "Song queue", you can now filter with the button group at the top right. Default is to show all songs, queued or sent:

![show-all](https://cloud.githubusercontent.com/assets/68917/17830499/6fb66114-66c5-11e6-9403-15cc41dede1c.png)

Toggle to "sent" to see which songs have gone out already:

![show-sent](https://cloud.githubusercontent.com/assets/68917/17830502/787e70a2-66c5-11e6-87de-5c28c2768631.png)

You should be able to check this branch out for yourself with the Heroku deploy app, link below titled "View Deployment".