### PR TITLE
Random song attribution

### DIFF
--- a/app/controllers/admin/random_controller.rb
+++ b/app/controllers/admin/random_controller.rb
@@ -3,14 +3,17 @@ class Admin::RandomController < Admin::AdminController
 
   def copy
     song = Song.find(params[:song_id])
-    song_params = %i(url title description image_url genre_ids).map do |attr|
-      [attr, song.send(attr)]
-    end.to_h
+    attributes = song.attributes.slice(*%w[url title image_url genre_ids])
+    attributes['description'] = <<-EOF.strip_heredoc.chomp
+      #{song.description}
+      
+      (Originally curated by #{song.curator.user.name})
+    EOF
 
     random = Curator.random
-    random.songs.create!(song_params)
+    random.songs.create!(attributes)
 
     redirect_to admin_curator_path(random),
-      notice: "Copied song to random song queue"
+      notice: 'Copied song to random song queue'
   end
 end

--- a/test/integration/random_test.rb
+++ b/test/integration/random_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+require_relative '../support/integration_test_helpers'
+require 'minitest/mock'
+
+class RandomTest < ActionDispatch::IntegrationTest
+  include IntegrationTestHelpers
+
+  test 'copy from curator queue' do
+    curator = users(:janet).curators.first
+
+    song = curator.songs.create!(url: 'https://youtube.com/song',
+                                 title: 'Queued Song',
+                                 description: 'Music noises',
+                                 image_url: 'https://i.ytimg.com/img.jpg',
+                                 genre_ids: [ genres(:pop).id ])
+
+    login_as users(:shannon)
+
+    # Visit curator page
+    get admin_curator_path(curator)
+    assert_response :success
+
+    # Should have a card for the song, which contains a "Random!" button
+    assert_select '.card', 1 do
+      assert_select "form[action='#{admin_random_copy_path(song)}']" do
+        assert_select 'input.btn[value="Random!"]', 1
+      end
+    end
+
+    # Click the "Random!" button
+    assert_difference -> { Curator.random.songs.queued.count }, 1 do
+      post admin_random_copy_path(song)
+    end
+
+    # Verify that the song was copied correctly
+    new_song = Curator.random.songs.queued.order(created_at: :desc).first
+    %i(url title description image_url genre_ids).each do |attr|
+      assert_equal song[attr], new_song[attr]
+    end
+  end
+end

--- a/test/integration/random_test.rb
+++ b/test/integration/random_test.rb
@@ -34,8 +34,12 @@ class RandomTest < ActionDispatch::IntegrationTest
 
     # Verify that the song was copied correctly
     new_song = Curator.random.songs.queued.order(created_at: :desc).first
-    %i(url title description image_url genre_ids).each do |attr|
+    %i(url title image_url genre_ids).each do |attr|
       assert_equal song[attr], new_song[attr]
     end
+
+    # Check that the description has attribution
+    description = "#{song.description}\n\n(Originally curated by #{curator.user.name})"
+    assert_equal description, new_song.description
   end
 end


### PR DESCRIPTION
Adds "(Originally curated by $CURATOR_NAME)" to the end of song descriptions copied using the "Random!" button in the admin.

Example of the result:

<img width="930" alt="screen shot 2016-08-21 at 19 50 07" src="https://cloud.githubusercontent.com/assets/68917/17839180/7ae422ce-67d8-11e6-941d-66c29710a1eb.png">

And here's the resulting song email (screenshot before #17 is merged):

<img width="624" alt="screen shot 2016-08-21 at 19 51 39" src="https://cloud.githubusercontent.com/assets/68917/17839195/bc0b9a5c-67d8-11e6-98e5-2288f10f3e62.png">

Fixes #14