### PR TITLE
use system fonts for admin panel

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,6 +19,11 @@
   display: flex;
   min-height: 100vh;
   flex-direction: column;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+
+  h1, h2, h3, h4 {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  }
 }
 
 .application-content {


### PR DESCRIPTION
Makes long lists and lots of data a bit easier to look at.

<img width="1440" alt="screen shot 2016-08-23 at 9 44 51 pm" src="https://cloud.githubusercontent.com/assets/1400729/17915723/dc25a776-697a-11e6-919b-6a645b3379ab.png">

@shannonbyrne plz review + merge.
