### PR TITLE
fix play button display bug

### DIFF
--- a/app/views/admin/curators/_curator.html.erb
+++ b/app/views/admin/curators/_curator.html.erb
@@ -34,7 +34,7 @@
           <span class="m-r-1 hidden-sm-down">Last song:</span>
           <% song = curator.songs.sent.order(:sent_at).last %>
           <% if song %>
-            <%= link_to raw("&#x25b6;"), song.url, target: "_blank", class: "btn btn-outline-primary m-r-1" %>
+            <%= link_to raw("&#x25b6;&#xfe0e;"), song.url, target: "_blank", class: "btn btn-outline-primary m-r-1" %>
             <strong>
               <%= link_to song.title, song.url, target: "_blank" %>
             </strong>


### PR DESCRIPTION
@shannonbyrne please review!

Fixes a problem where the play button would show up as an emoji, instead of the black triangle.

@alisdair fun fact: you can append `&#xfe0e;` to a unicode hex to indicate a preference for the text-like version instead of the color/emoji version